### PR TITLE
Error handling in deserialization of SQL rationals

### DIFF
--- a/src/rational.rs
+++ b/src/rational.rs
@@ -61,7 +61,7 @@ impl FromSql<Binary, Sqlite> for Rational {
         let denom = BigUint::from_bytes_le(denom);
 
         if denom.is_zero() {
-            return Err(Box::new(InvalidBlob {}));
+            return Err(Box::new(InvalidBlob));
         }
 
         Ok(Rational(Ratio::new(numer, denom)))

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -55,7 +55,7 @@ impl FromSql<Binary, Sqlite> for Rational {
         let (header, values) = get_split_at(bytes, 4).ok_or(InvalidBlob)?;
         let numer_len = u32::from_le_bytes(header.try_into().unwrap()) as usize;
 
-        let (numer, denom) = get_split_at(values, numer_len).ok_or(InvalidBlob {})?;
+        let (numer, denom) = get_split_at(values, numer_len).ok_or(InvalidBlob)?;
 
         let numer = BigUint::from_bytes_le(numer);
         let denom = BigUint::from_bytes_le(denom);

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -52,7 +52,7 @@ impl FromSql<Binary, Sqlite> for Rational {
         let bytes = <*const [u8] as FromSql<Binary, Sqlite>>::from_sql(bytes)?;
         let bytes: &[u8] = unsafe { &*bytes };
 
-        let (header, values) = get_split_at(bytes, 4).ok_or(InvalidBlob {})?;
+        let (header, values) = get_split_at(bytes, 4).ok_or(InvalidBlob)?;
         let numer_len = u32::from_le_bytes(header.try_into().unwrap()) as usize;
 
         let (numer, denom) = get_split_at(values, numer_len).ok_or(InvalidBlob {})?;

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -61,7 +61,7 @@ impl FromSql<Binary, Sqlite> for Rational {
         let denom = BigUint::from_bytes_le(denom);
 
         if denom.is_zero() {
-            return Err(Box::new(InvalidBlob));
+            return Err(InvalidBlob.into());
         }
 
         Ok(Rational(Ratio::new(numer, denom)))

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -34,11 +34,7 @@ impl std::fmt::Display for InvalidBlob {
     }
 }
 
-impl std::error::Error for InvalidBlob {
-    fn description(&self) -> &str {
-        "Invalid blob data in sqlite"
-    }
-}
+impl std::error::Error for InvalidBlob {}
 
 // Not (yet?) in the standard library.
 // From https://internals.rust-lang.org/t/slice-split-at-should-have-an-option-variant/17891

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -30,7 +30,7 @@ struct InvalidBlob;
 
 impl std::fmt::Display for InvalidBlob {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "Invalid blob data in sqlite")
+        write!(f, "invalid rational number")
     }
 }
 

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -4,7 +4,7 @@ use diesel::sql_types::Binary;
 use diesel::sqlite::{Sqlite, SqliteValue};
 use diesel::{AsExpression, FromSqlRow};
 use num::rational::Ratio;
-use num::BigUint;
+use num::{BigUint, Zero};
 
 #[derive(PartialEq, Eq, Debug, AsExpression, FromSqlRow)]
 #[diesel(sql_type = Binary)]
@@ -25,19 +25,50 @@ impl ToSql<Binary, Sqlite> for Rational {
     }
 }
 
+#[derive(Debug)]
+struct InvalidBlob;
+
+impl std::fmt::Display for InvalidBlob {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Invalid blob data in sqlite")
+    }
+}
+
+impl std::error::Error for InvalidBlob {
+    fn description(&self) -> &str {
+        "Invalid blob data in sqlite"
+    }
+}
+
+// Not (yet?) in the standard library.
+// From https://internals.rust-lang.org/t/slice-split-at-should-have-an-option-variant/17891
+#[inline]
+fn get_split_at(slice: &[u8], mid: usize) -> Option<(&[u8], &[u8])> {
+    if mid > slice.len() {
+        None
+    } else {
+        Some(slice.split_at(mid))
+    }
+}
+
 impl FromSql<Binary, Sqlite> for Rational {
     fn from_sql(bytes: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         let bytes = <*const [u8] as FromSql<Binary, Sqlite>>::from_sql(bytes)?;
         let bytes: &[u8] = unsafe { &*bytes };
 
-        let numer_len = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let (header, values) = get_split_at(bytes, 4).ok_or(InvalidBlob {})?;
+        let numer_len = u32::from_le_bytes(header.try_into().unwrap()) as usize;
 
-        let (numer, denom) = bytes[4..].split_at(numer_len as usize);
+        let (numer, denom) = get_split_at(values, numer_len).ok_or(InvalidBlob {})?;
 
-        Ok(Rational(Ratio::new(
-            BigUint::from_bytes_le(numer),
-            BigUint::from_bytes_le(denom),
-        )))
+        let numer = BigUint::from_bytes_le(numer);
+        let denom = BigUint::from_bytes_le(denom);
+
+        if denom.is_zero() {
+            return Err(Box::new(InvalidBlob {}));
+        }
+
+        Ok(Rational(Ratio::new(numer, denom)))
     }
 }
 
@@ -71,6 +102,46 @@ mod test {
             }],
             res.as_slice()
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn db_invalid_value_gives_error() -> Result<(), Box<dyn Error>> {
+        let mut conn = SqliteConnection::establish(":memory:")?;
+
+        #[derive(QueryableByName, PartialEq, Eq, Debug)]
+        struct Row {
+            #[diesel(sql_type = Binary)]
+            value: Rational,
+        }
+
+        let res = sql_query("SELECT X'' as value").load::<Row>(&mut conn);
+        assert!(res.is_err());
+
+        let res = sql_query("SELECT X'00000000' as value").load::<Row>(&mut conn);
+        assert!(res.is_err());
+
+        let res = sql_query("SELECT X'00000001' as value").load::<Row>(&mut conn);
+        assert!(res.is_err());
+
+        let res = sql_query("SELECT X'01000000' as value").load::<Row>(&mut conn);
+        assert!(res.is_err());
+
+        let res = sql_query("SELECT X'0100000001' as value").load::<Row>(&mut conn);
+        assert!(res.is_err());
+
+        // 1/1
+        let res = sql_query("SELECT X'010000000101' as value").load::<Row>(&mut conn);
+        assert!(res.is_ok());
+
+        // 1/1 with trailing zeroes (i.e. leading in big endian, so not contributing any value)
+        let res = sql_query("SELECT X'0100000001010000' as value").load::<Row>(&mut conn);
+        assert!(res.is_ok());
+
+        // 1/1 with trailing zeroes (i.e. leading in big endian, so not contributing any value)
+        let res = sql_query("SELECT X'020000000100010000' as value").load::<Row>(&mut conn);
+        assert!(res.is_ok());
 
         Ok(())
     }


### PR DESCRIPTION
🤔 Should I really be creating an error like that?
🧐 There should at least be some reuse between the `Display` and `Error` trait implementation...
🤨 Is there a nicer way to do something like `get_split_at`? (this way is definitely nicer than lots of `if`s, though)